### PR TITLE
Add React EnhancePanel demo with reset and editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,3 @@
-# mindpor
+# Mindpor
+
+This repository contains a placeholder UI located in the `public` directory. Open `public/index.html` in a browser to view the example page with a dark mode toggle. A simple React component (`src/components/EnhancePanel.jsx`) demonstrates editable suggestions and reset functionality.

--- a/public/index.html
+++ b/public/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Mindpor</title>
+  <!-- React and Babel for this simple demo -->
+  <script src="https://unpkg.com/react@18/umd/react.development.js" crossorigin></script>
+  <script src="https://unpkg.com/react-dom@18/umd/react-dom.development.js" crossorigin></script>
+  <script src="https://unpkg.com/@babel/standalone/babel.min.js" crossorigin></script>
+  <style>
+    body {
+      font-family: Arial, sans-serif;
+      margin: 0;
+      padding: 0;
+      text-align: center;
+      background-color: #fff;
+      color: #333;
+      transition: background-color 0.3s, color 0.3s;
+    }
+    header {
+      background-color: #4CAF50;
+      color: white;
+      padding: 1rem;
+    }
+    .dark-mode {
+      background-color: #333;
+      color: #fff;
+    }
+    button {
+      margin-top: 2rem;
+      padding: 0.5rem 1rem;
+      font-size: 1rem;
+    }
+  </style>
+</head>
+<body>
+  <header>
+    <h1>Mindpor</h1>
+  </header>
+  <main>
+    <p>Welcome to the Mindpor UI placeholder.</p>
+    <div id="panel"></div>
+    <button id="toggle">Toggle Dark Mode</button>
+  </main>
+  <script>
+    const button = document.getElementById('toggle');
+    button.addEventListener('click', () => {
+      document.body.classList.toggle('dark-mode');
+    });
+  </script>
+  <!-- Mount the React EnhancePanel component -->
+  <script type="text/babel" data-type="module" src="../src/components/EnhancePanel.jsx"></script>
+  <script type="text/babel">
+    const root = ReactDOM.createRoot(document.getElementById('panel'));
+    root.render(React.createElement(EnhancePanel, {}));
+  </script>
+</body>
+</html>

--- a/src/components/EnhancePanel.jsx
+++ b/src/components/EnhancePanel.jsx
@@ -1,0 +1,99 @@
+import React, { useState, useEffect } from 'react';
+
+// Placeholder utility to mimic updating nodes with suggestions
+// In a real application this should import from './metaUtils'
+function applyMetaSuggestions(nodes, suggestions) {
+  // Simply log and return nodes for placeholder purposes
+  console.log('Applying suggestions:', suggestions);
+  return nodes;
+}
+
+function EnhancePanel({ gptResponse, setGptResponse, nodesProp = [], setNodesProp }) {
+  const [editableSuggestions, setEditableSuggestions] = useState([]);
+  const [viewMode, setViewMode] = useState('pre-analysis');
+  const [processStatus, setProcessStatus] = useState(null);
+  const [errorMessage, setErrorMessage] = useState('');
+
+  useEffect(() => {
+    if (gptResponse) {
+      try {
+        const parsed = JSON.parse(gptResponse);
+        const suggs = parsed.suggestions || [];
+        setEditableSuggestions(JSON.parse(JSON.stringify(suggs)));
+        setViewMode('post-analysis');
+      } catch (err) {
+        setErrorMessage('Failed to parse AI response');
+      }
+    } else {
+      setViewMode('pre-analysis');
+      setEditableSuggestions([]);
+      setProcessStatus(null);
+      setErrorMessage('');
+    }
+  }, [gptResponse]);
+
+  const handleFieldEdit = (suggestionId, fieldPath, value) => {
+    setEditableSuggestions(current =>
+      current.map(sugg => {
+        if (sugg.id === suggestionId) {
+          const newSugg = JSON.parse(JSON.stringify(sugg));
+          let target = newSugg;
+          const parts = fieldPath.split('.');
+          for (let i = 0; i < parts.length - 1; i++) {
+            target[parts[i]] = target[parts[i]] || {};
+            target = target[parts[i]];
+          }
+          target[parts[parts.length - 1]] = value;
+          return newSugg;
+        }
+        return sugg;
+      })
+    );
+  };
+
+  const handleApplyAnalysis = () => {
+    if (!editableSuggestions.length || !setNodesProp) return;
+    const updatedNodes = applyMetaSuggestions(nodesProp, editableSuggestions);
+    setNodesProp(updatedNodes);
+  };
+
+  const handleReset = () => {
+    if (setGptResponse) setGptResponse('');
+    setViewMode('pre-analysis');
+    setEditableSuggestions([]);
+    setProcessStatus(null);
+    setErrorMessage('');
+  };
+
+  return (
+    <div className="enhance-panel">
+      {viewMode === 'pre-analysis' ? (
+        <div className="pre-analysis">
+          <textarea placeholder="Context/Goal" />
+          <button onClick={() => setProcessStatus('analyzing')}>✨ Analyze Flow</button>
+        </div>
+      ) : (
+        <div className="post-analysis">
+          <h3>AI Suggestions</h3>
+          <div className="suggestions">
+            {editableSuggestions.map(sugg => (
+              <div key={sugg.id} className="suggestion">
+                <input
+                  value={sugg.meta?.task || ''}
+                  onChange={e => handleFieldEdit(sugg.id, 'meta.task', e.target.value)}
+                />
+              </div>
+            ))}
+          </div>
+          <div className="actions">
+            <button onClick={handleApplyAnalysis}>Apply Edited Suggestions</button>
+            <button onClick={handleReset}>Reset</button>
+          </div>
+        </div>
+      )}
+      {errorMessage && <p className="error">{errorMessage}</p>}
+    </div>
+  );
+}
+
+export default EnhancePanel;


### PR DESCRIPTION
## Summary
- add a React EnhancePanel component with reset and editable suggestions
- load the component from `public/index.html`
- document the example component location in README

## Testing
- `git status --short`
